### PR TITLE
Bump version to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,155 @@
 
 - Make returnUrl optional in PortalSession.create mutation
 
+## 2.2.1 (2-Jul-2024)
+
+- Add return_url to portalsessioncreate mutation
+
+## 2.2.0 (26-Apr-2024)
+
+- Update to support new feature usage method
+
+## 2.1.1 (15-Mar-2024)
+
+- Add default timeout of 3 seconds
+
+## 2.1.0 (8-Mar-2024)
+
+- Update README.md
+
+## 2.0.3 (15-Feb-2024)
+
+- Handle all error formats
+
+## 2.0.2 (8-Feb-2024)
+
+- Add tenant metrics helper
+- Add evergreen to subscription
+
+## 2.0.1 (1-Feb-2024)
+
+- Add more logging
+- Add back host header
+- Include account_id in tenant create
+- Add new methods
+
+## 2.0.0 (25-Jan-2024)
+
+- Major version bump with significant API changes
+- Updated portal session helper
+- Allow setting host header
+
+## 1.26.0 (25-Jan-2023)
+
+- Add portal session method
+
+## 1.25.0 (25-Jan-2023)
+
+- Raise errors when in payload body
+- Fix product plan rename bugs
+
+## 1.23.0 (25-Jan-2023)
+
+- Upgrade to new bunny product name format
+
+## 1.22.0 (25-Jan-2023)
+
+- Increase fields returned by subscription
+- Add subscription example to docs
+
+## 1.21.0 (25-Jan-2023)
+
+- Support new subscription mutation
+
+## 1.18.0 (8-Jun-2022)
+
+- Remove platformCode
+
+## 1.17.0 (8-Jun-2022)
+
+- Return tenant code
+
+## 1.16.0 (8-Jun-2022)
+
+- Update sample tenant code
+- Rename to tenant
+
+## 1.15.0 (8-Jun-2022)
+
+- Make feature usage date optional
+
+## 1.14.0 (8-Jun-2022)
+
+- Add webhook signature verification
+
+## 1.13.0 (8-Jun-2022)
+
+- Version bump
+
+## 1.12.0 (8-Jun-2022)
+
+- Support new way of creating subscriptions
+
+## 1.11.0 (8-Jun-2022)
+
+- Add environment code link
+
+## 1.10.0 (8-Jun-2022)
+
+- Include method for trialCreate
+
+## 1.9.0 (8-Jun-2022)
+
+- Remove typo
+
+## 1.8.0 (8-Jun-2022)
+
+- Version bump
+
+## 1.7.0 (8-Jun-2022)
+
+- Renamed bunny app
+
+## 1.6.0 (8-Jun-2022)
+
+- Renamed to bunny
+
+## 1.5.0 (8-Jun-2022)
+
+- Create env and link subscription
+
+## 1.4.0 (8-Jun-2022)
+
+- Remove subscriptionId from env attributes
+
+## 1.3.0 (8-Jun-2022)
+
+- Raise errors based on http status codes
+
+## 1.2.0 (8-Jun-2022)
+
+- Support subscription_id on environment create
+
+## 1.1.0 (8-Jun-2022)
+
+- Add platform and environment support
+
+## 1.0.4 (8-Jun-2022)
+
+- Change gem name
+
+## 1.0.3 (8-Jun-2022)
+
+- Fix rails generator
+
+## 1.0.2 (8-Jun-2022)
+
+- Include generator in gem
+
+## 1.0.1 (8-Jun-2022)
+
+- Rebuild release 1.0.0
+
 ## 1.0.0 (10-Mar-2022)
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2 (13-Sep-2025)
+
+- Make returnUrl optional in PortalSession.create mutation
+
 ## 1.0.0 (10-Mar-2022)
 
 - Initial release


### PR DESCRIPTION
- Make returnUrl optional in PortalSession.create mutation
